### PR TITLE
Edit README.md to direct the use of .example.env

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -10,8 +10,5 @@ GH_CLIENT_ID=
 # Github OAuth client secret
 GH_CLIENT_SECRET=
 
-# Node environment type, either "production" or "development"
-NODE_ENV=
-
 # The web-facing url of the app
 PUBLIC_URL=

--- a/README.md
+++ b/README.md
@@ -11,17 +11,12 @@ This repo serves as the starting code for all of the CptS 489 project teams in t
 Fa20 semester. It will be pushed to their repos, deployed to their instances on
 AWS EB, and served through https://[proj-name].bfapp.org.
 
-To connect the app to your MongoDB database, create a .env file in the 
-project root directory. On the first line of that file, add this:
-MONGO_STR=<YOUR_MONGO_CONNECTION_STRING>
-
-You'll should also add the client ids and client secrets of each of your 
-OAuth providers to the .env file. Here's an example for GitHub:
-GH_CLIENT_ID='<CLIENT ID INSIDE QUOTES>'
-GH_CLIENT_SECRET='<CLIENT SECRET INSIDE QUOTES>'
-
-Make sure to add .env to your .gitignore file so that your secrets aren't
-stored in your GitHub repo!
+To set up environment variables, do the following:
+```shell script
+cp .example.env .env
+$EDITOR .env
+```
+You may swap `$EDITOR` for the text editor of your choice. Fill in the values.
 
 The app is presently set be served to http://localhost:8081 through the command
-npm run dev. You'll need to update DEPLOY_URL in server.js for remote deployment.
+npm run dev. You'll need to update DEPLOY_URL in main.js for remote deployment.


### PR DESCRIPTION
This change keeps README.md up to date with our current setup. `NODE_ENV` has been removed from `.example.env`, as it is best set elsewhere.