### PR TITLE
Fix redirect after round add/edit/delete

### DIFF
--- a/client/src/components/Rounds.js
+++ b/client/src/components/Rounds.js
@@ -42,8 +42,7 @@ class Rounds extends React.Component {
             this.setState({errorMsg: ""});
             await this.props.refreshOnUpdate();
         }
-        const history = useHistory();
-        history.push(this.url)
+        this.props.history.goBack()
     }
 
     //editRound -- Given an object newData containing updated data on an
@@ -66,8 +65,7 @@ class Rounds extends React.Component {
         } else {
             await this.props.refreshOnUpdate();
         }
-        const history = useHistory();
-        history.push(this.url)
+        this.props.history.goBack()
     }
 
 

--- a/client/src/components/RoundsTable.js
+++ b/client/src/components/RoundsTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ConfirmDeleteRound from './ConfirmDeleteRound.js';
 import {Link, Switch, Route, useHistory} from "react-router-dom";
+import {withRouter} from "react-router";
 
 class RoundsTable extends React.Component {
   //passed tableMode in which holds the table mode
@@ -18,8 +19,7 @@ class RoundsTable extends React.Component {
   }
 
   closeDeleteRoundsModal = () => {
-    const history = useHistory();
-    history.push("/rounds");
+    this.props.history.push("/rounds");
   }
 
   //renderTable -- render an HTML table displaying the rounds logged
@@ -96,4 +96,4 @@ class RoundsTable extends React.Component {
   }
 }
 
-export default RoundsTable;
+export default withRouter(RoundsTable);


### PR DESCRIPTION
Previously, the app would break after attempting to add a round. This change should instead cause the app to redirect to the appropriate table. As it turns out, I was previously using history incorrectly, which caused React to raise an error.