### PR TITLE
Add different views for students and admins

### DIFF
--- a/client/src/components/AdminView.js
+++ b/client/src/components/AdminView.js
@@ -1,0 +1,24 @@
+import React from "react";
+import {Route, Switch} from "react-router-dom";
+import Majors from "../Majors";
+import Rounds from "./Rounds";
+
+class AdminView extends React.Component {
+    render() {
+        return (
+            <Switch>
+                {Object.values(Majors).map((major) =>
+                    <Route path={major.path}>
+                        <Rounds
+                            userObj={this.props.userObj}
+                            refreshOnUpdate={this.props.refreshOnUpdate}
+                            menuOpen={this.props.menuOpen}
+                        />
+                    </Route>
+                )}
+            </Switch>
+        )
+    }
+}
+
+export default AdminView;

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -8,6 +8,8 @@ import Rounds from './Rounds.js';
 import AboutBox from './AboutBox.js';
 import {Redirect, Route, Switch} from "react-router-dom";
 import Majors from "../Majors";
+import AdminView from "./AdminView";
+import StudentView from "./StudentView";
 
 
 class App extends React.Component {
@@ -157,17 +159,14 @@ class App extends React.Component {
                                     menuOpen={this.state.menuOpen}
                                     modes={Object.values(Majors)}
                                 />
-                                <Switch>
-                                    {Object.values(Majors).map((major) =>
-                                        <Route path={major.path}>
-                                            <Rounds
-                                                userObj={this.state.userObj}
-                                                refreshOnUpdate={this.refreshOnUpdate}
-                                                menuOpen={this.state.menuOpen}
-                                            />
-                                        </Route>
-                                    )}
-                                </Switch>
+                                {this.state.userObj.admin
+                                    ? <AdminView
+                                        userObj={this.state.userObj}
+                                        refreshOnUpdate={this.refreshOnUpdate}
+                                        menuOpen={this.state.menuOpen}
+                                    />
+                                    : <StudentView/>
+                                }
                             </>
                             : <Redirect to="/login" />
                         }

--- a/client/src/components/StudentView.js
+++ b/client/src/components/StudentView.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+class StudentView extends React.Component {
+    render() {
+        return (
+            <>
+            </>
+        )
+    }
+}
+
+export default StudentView;


### PR DESCRIPTION
This change splits whether the student or admin pages are displayed. As of now the student page is empty. This is dependent on the value of `userObj.admin`.